### PR TITLE
Update servers.yaml example format

### DIFF
--- a/entities.adoc
+++ b/entities.adoc
@@ -31,15 +31,15 @@ YAML files are the default expected format, so you can use .yml, .yaml, or even 
 .`/etc/OliveTin/servers.yaml`
 [source,yaml]
 ----
-server1:
+- name: server1
   state: started
   hostname: server1.example.com
   ip: 192.168.0.1
-server2:
+- name: server2
   state: started
   hostname: server2.example.com
   ip: 192.168.0.2
-server3:
+- name: server3
   state: stopped
   hostname: server3.example.com
   ip: 192.168.0.3


### PR DESCRIPTION
Correct the servers.yaml example format in the documentation. The old dictionary method didn't work as expected. Changed to a list format to ensure clarity and remove confusion regarding the correct structure.