### PR TITLE
Update ACL YAML Attribute

### DIFF
--- a/modules/ROOT/pages/security/acl.adoc
+++ b/modules/ROOT/pages/security/acl.adoc
@@ -61,7 +61,7 @@ accessControlLists:
       exec: true
 
   - name: james
-    matchUsers:
+    matchUserNames:
       - james
     permissions:
       view: true


### PR DESCRIPTION
Based on error output from the console, I figured out that the docs use the wrong YAML attribute `matchUsers`.
Corrected to `matchUserNames`