### PR TITLE
Revise documentation for wol solution

### DIFF
--- a/modules/ROOT/pages/solutions/wol/config.yaml
+++ b/modules/ROOT/pages/solutions/wol/config.yaml
@@ -1,10 +1,10 @@
 actions:
   - title: WakeOnLan Server1
-    shell: awake A8:5E:45:E4:FF:2A
+    shell: ether-wake A8:5E:45:E4:FF:2A
     icon: ping
 
-  - title: Install awake on startup
-    shell: microdnf install -y awake
+  - title: Install ether-wake on startup
+    shell: microdnf install -y net tools
     hidden: true
     execOnStartup: true
     timeout: 120

--- a/modules/ROOT/pages/solutions/wol/index.adoc
+++ b/modules/ROOT/pages/solutions/wol/index.adoc
@@ -1,12 +1,12 @@
 [#wol]
 === Wake On LAN from a container
 
-This is a simple solution that provides wake on lan capabilities from inside a container. It uses the simple `awake` command to send the magic packet. This can be incredibly helpful if you just need a simple button to click to wake up a machine on your network.
+This is a simple solution that provides wake on lan capabilities from inside a container. It uses the simple `ether-wake` command to send the magic packet. This can be incredibly helpful if you just need a simple button to click to wake up a machine on your network.
 
 Docker containers will normally use a docker network, which is a separate network from the host network. This means that the container will not be able to send the magic packet to the host network. Therefore, we need to create the container with the `--network host` option, which will allow the container to send the magic packet to the host network (not the docker network).
 
 
-The container is also created with the `--user root` option, which allows the container to send the magic packet as root. This is necessary because the `awake` command requires root privileges to send the magic packet, and also to install the `awake` command in the container.
+The container is also created with the `--user root` option, which allows the container to send the magic packet as root. This is necessary because the `ether-wake` command requires root privileges to send the magic packet, and also to install the `ether-wake` command, which is bundled with `net-tools` in the container.
 
 Create the container as follows;
 


### PR DESCRIPTION
The `awake` command seems to be supported up to fedora 38. The latest docker image builds a fedora 40 container. The `ether-wake` command works just fine and in a very similar way too so i thought i would update the docs while im at it