### PR TITLE
Recommend read-only as the default for config mounts

### DIFF
--- a/modules/ROOT/examples/reverse-proxies/etc/npm-docker-compose.yml
+++ b/modules/ROOT/examples/reverse-proxies/etc/npm-docker-compose.yml
@@ -13,7 +13,7 @@ services:
     container_name: olivetin
     image: jamesread/olivetin
     volumes:
-      - ./OliveTin:/config # replace host path or volume as needed
+      - ./OliveTin:/config:ro # replace host path or volume as needed
     ports:
       - "1337:1337"
     restart: unless-stopped

--- a/modules/ROOT/pages/action_examples/ssh-manual.adoc
+++ b/modules/ROOT/pages/action_examples/ssh-manual.adoc
@@ -121,7 +121,7 @@ You should mount your SSH keys directory into the OliveTin user's home directory
 +
 .If you want to create the container from the command line
 ----
-docker run -v /opt/OliveTinSshKeys/:/home/olivetin/.ssh/ -v /etc/OliveTin/:/config --name OliveTin jamesread/olivetin
+docker run -v /opt/OliveTinSshKeys/:/home/olivetin/.ssh/ -v /etc/OliveTin/:/config:ro --name OliveTin jamesread/olivetin
 ----
 +
 .If you are using docker-compose
@@ -132,7 +132,7 @@ services:
         container_name: olivetin
         image: jamesread/olivetin
         volumes:
-          - "/etc/OliveTin/:/config"
+          - "/etc/OliveTin/:/config:ro"
           - "/opt/OliveTinSshKeys:/home/olivetin/.ssh"
         ports:
           - "1337:1337"

--- a/modules/ROOT/pages/advanced_configuration/timezones.adoc
+++ b/modules/ROOT/pages/advanced_configuration/timezones.adoc
@@ -9,10 +9,10 @@ To change the time in the OliveTin container, simply bind-mount the correct zone
 
 .Same as the container host
 ----
-docker create -v /etc/localtime:/etc/localtime -v /etc/OliveTin:/config --name OliveTin docker.io/jamesread/olivetin
+docker create -v /etc/localtime:/etc/localtime -v /etc/OliveTin:/config:ro --name OliveTin docker.io/jamesread/olivetin
 ----
 
 .Different timezone to the container host
 ----
-docker create -v /usr/share/zoneinfo/Japan:/etc/localtime -v /etc/OliveTin:/config --name OliveTin docker.io/jamesread/olivetin
+docker create -v /usr/share/zoneinfo/Japan:/etc/localtime -v /etc/OliveTin:/config:ro --name OliveTin docker.io/jamesread/olivetin
 ----

--- a/modules/ROOT/pages/install/docker_compose.adoc
+++ b/modules/ROOT/pages/install/docker_compose.adoc
@@ -15,7 +15,7 @@ services:
     container_name: olivetin
     image: jamesread/olivetin
     volumes:
-      - OliveTin-config:/config # replace host path or volume as needed
+      - OliveTin-config:/config:ro # replace host path or volume as needed
     ports: 
       - "1337:1337"
     restart: unless-stopped
@@ -36,7 +36,7 @@ services:
     container_name: olivetin
     image: jamesread/olivetin
     volumes:
-      - /docker/OliveTin:/config # replace host path or volume as needed
+      - /docker/OliveTin:/config:ro # replace host path or volume as needed
       - /var/run/docker.sock:/var/run/docker.sock 
     ...
 ----

--- a/modules/ROOT/pages/reference/multiple_instances.adoc
+++ b/modules/ROOT/pages/reference/multiple_instances.adoc
@@ -9,7 +9,7 @@ This is the easiest way to run multiple OliveTin instances. Follow the xref:inst
 
 1. Create a `config.yaml` file for each instance of OliveTin (instances cannot share the same config).
 2. Choose a new external port for OliveTin and set it in the config file (by default that is `1337` is used). For example, set `listenAddressSingleHTTPFrontend: 0.0.0.0:2337` for your 2nd container's config.
-3. When creating the container, pass in the 2nd instance's config, eg; `-v /opt/OliveTin_two/:/config/`
+3. When creating the container, pass in the 2nd instance's config, eg; `-v /opt/OliveTin_two/:/config/:ro`
 4. When creating the container, set the external port, eg: `2337:1337` - 2337 is the external port)
 
 You do not need to change the listenAddresses / ports for the other 3 ports that OliveTin uses, when you are running inside a container. 

--- a/modules/ROOT/pages/reverse-proxies/traefik.adoc
+++ b/modules/ROOT/pages/reverse-proxies/traefik.adoc
@@ -12,7 +12,7 @@ services:
     container_name: olivetin
     image: jamesread/olivetin
     volumes:
-      - /docker/olivetin:/config # replace host path or volume as needed
+      - /docker/olivetin:/config:ro # replace host path or volume as needed
     ports:
       - "1337:1337"
     restart: unless-stopped

--- a/modules/ROOT/pages/solutions/wol/index.adoc
+++ b/modules/ROOT/pages/solutions/wol/index.adoc
@@ -11,7 +11,7 @@ The container is also created with the `--user root` option, which allows the co
 Create the container as follows;
 
 ```bash
-user@host: docker create -u root --network=host --name olivetin_wol -v /etc/OliveTin/:/config ghcr.io/olivetin/olivetin:latest
+user@host: docker create -u root --network=host --name olivetin_wol -v /etc/OliveTin/:/config:ro ghcr.io/olivetin/olivetin:latest
 ```
 
 Create your OliveTin `config.yaml` file in the `/etc/OliveTin/` directory on the host, with the following content;


### PR DESCRIPTION
Unless you've got a really, really good reason to make OliveTin's config directory writable, this should be the default everywhere.