### PR TITLE
Fix link to how to install additional packages

### DIFF
--- a/modules/ROOT/partials/container_socket.adoc
+++ b/modules/ROOT/partials/container_socket.adoc
@@ -20,7 +20,7 @@ docker run --privileged --user root -v /var/run/docker.sock:/var/run/docker.sock
 +
 . The official x86_64 docker container comes with the `docker` client pre-installed. If you are using `arm` or and `arm64` container, you will need to add Docker yourself.
 +
-<<container-dnf,How to install additional packages in the container>>
+xref:reference/containerInstallPackages.adoc[How to install additional packages in the container]
 +
 NOTE: The reason that the `arm` and `arm64` containers do not include docker, is that when these images are cross-compiled at build time, it takes FOREVER because we have to emulate arm.
 


### PR DESCRIPTION
This is broken on https://docs.olivetin.app/solutions/container-control-panel/