### PR TITLE
Document WoL solution via docker container, expand on docker container privileges

### DIFF
--- a/modules/ROOT/examples/solutions/wol/config_docker.yaml
+++ b/modules/ROOT/examples/solutions/wol/config_docker.yaml
@@ -1,0 +1,6 @@
+  - title: WakeOnLan Server1
+    # The r0gger/docker-wake-on-lan is a minimal container for WOL
+    # that can be run on the host network.
+    # It is not required to run the OliveTin container on the host network.
+    shell: |
+     docker run --rm --name wake-on-lan --net=host -e MAC='A8:5E:45:E4:FF:2A' r0gger/docker-wake-on-lan

--- a/modules/ROOT/pages/install/docker_compose.adoc
+++ b/modules/ROOT/pages/install/docker_compose.adoc
@@ -35,6 +35,8 @@ If you want to use OliveTin running in a container to control other Docker conta
 You will need to adjust your docker-compose file to include the docker socket, like this;
 
  `docker-compose.yml` including docker socket
+[source,yaml]
+.docker-compose.yml
 ----
 services:
   olivetin:
@@ -60,6 +62,9 @@ services:
     user: root 
     ...
 ----
+
+See xref:action_examples/containers.adoc[containers] for alternatives to running as root.
+
 
 NOTE: xref:troubleshooting/puid-pgid.adoc[PUID and PGID are not used] by the official OliveTin container image.
 

--- a/modules/ROOT/pages/solutions/wol/index.adoc
+++ b/modules/ROOT/pages/solutions/wol/index.adoc
@@ -33,4 +33,22 @@ Then visit your OliveTin web interface at http://yourServer:1337 and you should 
 
 image::solutions/wol/preview.png[]
 
+== Wake on LAN via docker container
 
+This is an alternative solution that provides WoL capabilities to the OliveTin container,
+
+but has the advantage the OliveTin container does not have to run on the host network ( `--network host` ).
+This may be useful if your networking configuration relies on docker `bridge`
+networks (or other more complex networking configurations).
+
+It requires that OliveTin is configured with permissions that allow it to control docker. 
+
+include::partial$container_socket.adoc[]
+
+Now you can add actions to your OliveTin config file that use a separate
+docker container (on the `host` network) to send the WOL commands.
+
+[source,yaml]
+----
+include::example$solutions/wol/config_docker.yaml[]
+----

--- a/modules/ROOT/partials/container_socket.adoc
+++ b/modules/ROOT/partials/container_socket.adoc
@@ -4,9 +4,54 @@ You can control other containers, when running OliveTin inside a container
 itself, however you need to do some extra setup when creating the OliveTin
 container.
 
-NOTE: If you want to control Docker from inside a Docker container, you will need to also create the container with `--privileged`. Podman does not have this requirement. If you are getting "permission denied" errors it is probably because OliveTin runs as user UID 1000 by default, which is not allowed by your docker host. Simply run OliveTin with `--user root` as a simple workround. Note that <<no-puid-pgid,PUID and PGID variables will not work>>.
+=== Ensure your container has permissions to control docker
+
+You have two alternatives to allow OliveTin (running inside a container) to talk to the Docker daemon through the bind-mounted socket. Pick one:
+
+==== Option 1 — Use `--privileged` (simplest)
+
+NOTE: Simplest for most users. Podman does not have this requirement.
+
+- Run the container with `--privileged` and as `root` (eg `--user root`).
+- This avoids user/group permission issues on `/var/run/docker.sock`.
+
+If you are getting "permission denied" errors it is probably because OliveTin runs as user UID 1000 by default, which is not allowed by your docker host. Running with `--user root` under `--privileged` resolves this quickly. Note that <<no-puid-pgid,PUID and PGID variables will not work>>.
+
+==== Option 2 — Run as non-root in the host `docker` group (no `--privileged`)
+
+Use the standard Docker guidance to manage Docker as a non-root user (becoming a member of the `docker` group) and match the group's GID inside the container so the process can access the socket permissions.
+
+- Docs: https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user[Manage Docker as a non-root user]
+- Find the `docker` group GID on the host, for example using `getent group docker`.
+- Run the container with your user UID and the `docker` group GID, and bind-mount the socket. Using Compose:
+
+[source,yaml]
+.docker-compose.yml
+----
+services:
+  olivetin:
+    container_name: olivetin
+    image: jamesread/olivetin
+    user: ${UID}:${docker_group_id}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+----
+
+Where `UID` and `docker_group_id` are provided via your shell environment or a `.env` file next to your Compose file, for example:
+
+[source,bash]
+.env
+----
+UID=1000
+docker_group_id=995
+----
+
+This allows you to run the container as a non-root user, while still allowing access to `/var/run/docker.sock`.
+
+=== Pass the docker socket into the container
 
 . Pass `/var/run/docker.sock` as a bind mount to the container when creating it, eg:
+
 +
 ----
 docker create --privileged --user root -v /var/run/docker.sock:/var/run/docker.sock ...additional args here...


### PR DESCRIPTION
The docker container privelege stuff might actually benefit from further refactoring, because there are scattered references to mounting the docker socket in the `install` page as well, which also describes setting the user to root.

I've tried to link those back to more comprehensive docs (ones that include the container socket asciidoc)